### PR TITLE
Add keep() helper for glossary entries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,17 @@ Version 0.2.0
 
 To be released.
 
+### @vertana/core
+
+ -  Added `keep()` helper function for creating glossary entries that preserve
+    terms without translation.  [[#3], [#5]]
+
+ -  Added `properNoun()` as an alias for `keep()`, for semantic clarity when
+    preserving brand names and product names.  [[#3], [#5]]
+
+[#3]: https://github.com/dahlia/vertana/issues/3
+[#5]: https://github.com/dahlia/vertana/pull/5
+
 
 Version 0.1.0
 -------------

--- a/docs/manuals/glossary.md
+++ b/docs/manuals/glossary.md
@@ -75,6 +75,56 @@ const entry: GlossaryEntry = {
     disambiguate terms with multiple meanings.
 
 
+Preserving terms with `keep()`
+------------------------------
+
+Some terms should remain untranslated—brand names, product names, and certain
+technical terms often need to stay in their original form.  Instead of writing
+`{ original: "React", translated: "React" }`, use the `keep()` helper:
+
+~~~~ typescript twoslash
+import { keep } from "@vertana/core/glossary";
+import { translate } from "@vertana/facade";
+import { openai } from "@ai-sdk/openai";
+
+const result = await translate(
+  openai("gpt-4o"),
+  "ko",
+  "The React component uses hooks for state management.",
+  {
+    glossary: [
+      keep("React"),
+      keep("hook", { context: "React programming concept" }),
+    ],
+  }
+);
+~~~~
+
+The `properNoun()` function is an alias for `keep()` that provides semantic
+clarity when preserving proper nouns:
+
+~~~~ typescript twoslash
+import { properNoun } from "@vertana/core/glossary";
+import { translate } from "@vertana/facade";
+import { openai } from "@ai-sdk/openai";
+
+const result = await translate(
+  openai("gpt-4o"),
+  "ko",
+  "TypeScript was developed by Microsoft.",
+  {
+    glossary: [
+      properNoun("TypeScript"),
+      properNoun("Microsoft"),
+    ],
+  }
+);
+~~~~
+
+Both functions accept an optional `context` parameter for disambiguation, just
+like regular glossary entries.
+
+
 Context-aware entries
 ---------------------
 
@@ -262,6 +312,23 @@ Don't include every word.  Focus on:
  -  Technical vocabulary specific to your domain
  -  Terms with multiple possible translations
  -  Proper nouns that need consistent transliteration
+
+
+### Use helpers for untranslated terms
+
+When a term should remain in its original form, use `keep()` or `properNoun()`
+for readability instead of writing `{ original: "X", translated: "X" }`:
+
+~~~~ typescript twoslash
+import { type Glossary, keep, properNoun } from "@vertana/core/glossary";
+
+const glossary: Glossary = [
+  properNoun("React"),
+  properNoun("TypeScript"),
+  keep("API"),
+  keep("LLM", { context: "Large Language Model" }),
+];
+~~~~
 
 
 ### Provide context for ambiguous terms

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -200,6 +200,29 @@ console.log(result.text);
 // => "React 컴포넌트는 상태 관리를 위해 훅을 사용합니다. 각 훅은 훅의 규칙을 따릅니다."
 ~~~~
 
+For terms that should remain untranslated (like "React" above), you can use the
+`keep()` or `properNoun()` helper functions instead of repeating the same value:
+
+~~~~ typescript twoslash
+import { properNoun } from "@vertana/core/glossary";
+import { translate } from "@vertana/facade";
+import { openai } from "@ai-sdk/openai";
+
+const result = await translate(
+  openai("gpt-4o"),
+  "ko",
+  "The React component uses hooks for state management. Each hook follows the rules of hooks.",
+  {
+    glossary: [
+      properNoun("React"),              // Same as { original: "React", translated: "React" }
+      { original: "component", translated: "컴포넌트" },
+      { original: "hook", translated: "훅" },
+      { original: "state", translated: "상태" }
+    ]
+  }
+);
+~~~~
+
 
 ### Glossary with context
 

--- a/packages/core/src/glossary.test.ts
+++ b/packages/core/src/glossary.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from "./test-compat.ts";
+import assert from "node:assert/strict";
+import { keep, properNoun } from "./glossary.ts";
+
+describe("keep", () => {
+  it("creates a glossary entry with same original and translated", () => {
+    const entry = keep("React");
+    assert.equal(entry.original, "React");
+    assert.equal(entry.translated, "React");
+    assert.equal(entry.context, undefined);
+  });
+
+  it("accepts context option", () => {
+    const entry = keep("hook", { context: "React programming concept" });
+    assert.equal(entry.original, "hook");
+    assert.equal(entry.translated, "hook");
+    assert.equal(entry.context, "React programming concept");
+  });
+});
+
+describe("properNoun", () => {
+  it("is an alias for keep", () => {
+    assert.strictEqual(properNoun, keep);
+  });
+
+  it("creates a glossary entry with same original and translated", () => {
+    const entry = properNoun("TypeScript");
+    assert.equal(entry.original, "TypeScript");
+    assert.equal(entry.translated, "TypeScript");
+  });
+});

--- a/packages/core/src/glossary.ts
+++ b/packages/core/src/glossary.ts
@@ -23,3 +23,53 @@ export interface GlossaryEntry {
    */
   readonly context?: string;
 }
+
+/**
+ * Options for the {@link keep} function.
+ * @since 0.2.0
+ */
+export type KeepOptions = Omit<GlossaryEntry, "original" | "translated">;
+
+/**
+ * Creates a glossary entry that preserves the original term without translation.
+ * Use this for brand names, technical terms, or any text that should remain as-is.
+ *
+ * @param term The term to preserve in its original form.
+ * @param options Optional settings including context for disambiguation.
+ * @returns A glossary entry with the same value for both original and translated.
+ * @since 0.2.0
+ *
+ * @example
+ * ```typescript
+ * glossary: [
+ *   keep("React"),
+ *   keep("TypeScript", { context: "programming language" }),
+ * ]
+ * ```
+ */
+export function keep(term: string, options?: KeepOptions): GlossaryEntry {
+  return {
+    original: term,
+    translated: term,
+    ...options,
+  };
+}
+
+/**
+ * Alias for {@link keep}. Creates a glossary entry that preserves a proper noun
+ * (brand name, product name, etc.) without translation.
+ *
+ * @param term The proper noun to preserve.
+ * @param options Optional settings including context for disambiguation.
+ * @returns A glossary entry with the same value for both original and translated.
+ * @since 0.2.0
+ *
+ * @example
+ * ```typescript
+ * glossary: [
+ *   properNoun("React"),
+ *   properNoun("TypeScript"),
+ * ]
+ * ```
+ */
+export const properNoun = keep;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,7 +30,13 @@ export type {
   ChunkType,
   TokenCounter,
 } from "./chunking.ts";
-export type { Glossary, GlossaryEntry } from "./glossary.ts";
+export {
+  type Glossary,
+  type GlossaryEntry,
+  keep,
+  type KeepOptions,
+  properNoun,
+} from "./glossary.ts";
 export type {
   AdaptiveContextWindow,
   ContextWindow,


### PR DESCRIPTION
This pull request closes #3.

This adds a helper function, `keep()` that creates glossary entries preserving the original term without translation, useful for:

 - Brand names and product names (React, TypeScript)
 - Technical terminology
 - Acronyms and abbreviations

Also adds `properNoun()` as an alias for semantic clarity.